### PR TITLE
Add an initial roadmap.

### DIFF
--- a/documents/roadmap.md
+++ b/documents/roadmap.md
@@ -1,0 +1,46 @@
+# Roadmap
+
+This document states what our next goal is, and which objectives we have to
+accomplish to consider the goal as "done". This document should evolve as we
+make progress.
+
+## Current goal
+
+**Goal**: cross-compiling to `nvptx` from the Tier-1 `x86_64` targets should
+always work. This moves `nvptx` from a Tier-3 to a Tier-2 target.
+
+## Objectives
+
+**Main objective**: create an example host crate that links to a device crate
+containing a simple kernel using some `core::arch::nvptx` intrinsics and math
+function. Launch the kernel from the host crate using `cuda-sys`. 
+
+Compiling these crates from the `x86_64` Tier-1 targets should never fail. That
+is, PRs to `rustc`, `libcore` (`stdsimd`, etc.) that would break the build for
+this example crate should not be merge-able - that is, the CI systems of
+`rustc`, `stdsimd`, etc. will detect this and fail.
+
+Our current goal is only about making sure that cross-compiling always works.
+That is, ensuring that the host crate actually runs correctly and passes a
+run-time tests, e.g., with the kernel running on a real GPU, is not necessary to
+achieve our goal and is not part of the objective - it could be our next goal.
+
+This main objective is split into 4 sub-objectives:
+
+**compiler**: we need to make sure that the compiler is always able to compile
+`nvptx` kernels without erroring. We should add tests for this, and enable those
+in Rust's CI. This would be codegen tests, compile-pass tests, etc. No run-time
+tests at this point.
+
+**library**: we need to make sure that the `nvptx` intrinsics (e.g.
+`syncthreads`) always compile. We need to add tests to `stdsimd` to build these
+intrinsics. 
+
+**linker**: we need to make sure that linking `nvptx` to the host crate always
+work, we need to test this, and we need to make sure that rustc changes are
+blocked on not breaking this.
+
+**testing**: our first focus is on getting the toolchain to an "always builds"
+state. However, "always builds" is not very useful if nothing works at run-time.
+We should implement ways of testing that the `ptx` code generated is correct,
+without doing run-time tests.


### PR DESCRIPTION
[Rendered](https://github.com/gnzlbg/wg/blob/initial_roadmap/documents/roadmap.md).

It appears that my proposed roadmap of issue #4 had some general consensus, this summarizes that and tries to focus the work a bit more, in that our first goal should only be that basic stuff should always build. I think that making sure that everything works properly at run-time is a more complicated issue due to the difficulties of testing CUDA kernels on CI - in particular, if we wanted to integrate something like that in Rust's CI. I think that is a problem that we will definitely have to solve right afterwards, and / or in parallel, but does not necessary have to be part of our very first goal. 

The more concrete objectives are kept intentionally vague. Once we agree on this, we should open one issue per objective, to try to discuss the options we have to solve each of them, and get on the same page about the best approach.

Thoughts? 

Closes #4 .