### PR TITLE
Link roadmap in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Rust CUDA Working Group
+# Rust CUDA Team
 
-> Coordination repository of the Rust CUDA Working Group (WG)
+> Coordination repository of the Rust CUDA Team
 
 See [Issue 1: Try to bootstrap a Rust CUDA Working
 Group](https://github.com/rust-cuda/wg/issues/1).
@@ -17,10 +17,16 @@ Group](https://github.com/rust-cuda/wg/issues/1).
 * @Dylan-DPC
 * @DiamondLovesYou
 
+(if you'd like to join the team, send a PR adding yourself to the list)
+
 **Contact:**
 
 * Chat: https://rust-cuda.zulipchat.com
 * Github: https://github.com/rust-cuda/wg
+
+## Roadmap
+
+[Roadmap](documents/roadmap.md).
 
 ## License
 
@@ -37,7 +43,6 @@ at your option.
 ## Contributing
 
 We welcome all people who want to contribute.
-Please see the [contributing instructions] for more information.
 
 Contributions in any form (issues, pull requests, etc.) to this project
 must adhere to Rust's [Code of Conduct].

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 > Coordination repository of the Rust CUDA Team
 
-See [Issue 1: Try to bootstrap a Rust CUDA Working
-Group](https://github.com/rust-cuda/wg/issues/1).
-
 ## Organization
 
 **Team:**
@@ -27,6 +24,8 @@ Group](https://github.com/rust-cuda/wg/issues/1).
 ## Roadmap
 
 [Roadmap](documents/roadmap.md).
+
+**Active discussion issues**: TBD.
 
 ## License
 


### PR DESCRIPTION
This also renames us to "Rust CUDA Team" to avoid confusion with working groups until Rust 2018 is released and Rust upstream sorts out the process for creating more working groups.